### PR TITLE
fix spelling error tranfer to transfer, fix error code.

### DIFF
--- a/src.ts/non-fungible-token.ts
+++ b/src.ts/non-fungible-token.ts
@@ -688,7 +688,7 @@ export class NonFungibleToken {
      * @param overrides options
      */
     static approveNonFungibleTokenOwnership(symbol: string, signer: Signer, overrides?: any) {
-        return setNonFungibleTokenStatus(symbol, "APPROVE_TRANFER_TOKEN_OWNERSHIP", signer, overrides);
+        return setNonFungibleTokenStatus(symbol, "APPROVE_TRANSFER_TOKEN_OWNERSHIP", signer, overrides);
     }
 
     /**
@@ -698,7 +698,7 @@ export class NonFungibleToken {
      * @param overrides options
      */
     static rejectNonFungibleTokenOwnership(symbol: string, signer: Signer, overrides?: any) {
-        return setNonFungibleTokenStatus(symbol, "REJECT_TRANFER_TOKEN_OWNERSHIP", signer, overrides);
+        return setNonFungibleTokenStatus(symbol, "REJECT_TRANSFER_TOKEN_OWNERSHIP", signer, overrides);
     }
 
     /**
@@ -880,8 +880,8 @@ function setNonFungibleTokenStatus(symbol: string, status: string, signer: Signe
             }
             break;
 
-        case "APPROVE_TRANFER_TOKEN_OWNERSHIP":
-        case "REJECT_TRANFER_TOKEN_OWNERSHIP":
+        case "APPROVE_TRANSFER_TOKEN_OWNERSHIP":
+        case "REJECT_TRANSFER_TOKEN_OWNERSHIP":
         case "REJECT":
         case "FREEZE":
         case "UNFREEZE":

--- a/src.ts/providers/json-rpc-provider.ts
+++ b/src.ts/providers/json-rpc-provider.ts
@@ -556,8 +556,12 @@ function checkResponseLog(self: JsonRpcProvider, method: string, result: any, de
                     case 2107:
                         return errors.createError('token item frozen', errors.NOT_ALLOWED, { operation: method, info, response: result, params });
                     case 2108:
-                        return errors.createError('invalid item holder', errors.NOT_ALLOWED, { operation: method, info, response: result, params });
+                        return errors.createError('token item unfrozen', errors.NOT_ALLOWED, { operation: method, info, response: result, params });
+                    case 2109:
+                        return errors.createError('invalid item owner', errors.NOT_ALLOWED, { operation: method, info, response: result, params });
                     case 2110:
+                        return errors.createError('token item not modifiable', errors.NOT_ALLOWED, { operation: method, info, response: result, params });
+                    case 2111:
                         return errors.createError('token item not found', errors.NOT_FOUND, { operation: method, info, response: result, params });
 
                     case 3001: // Fee setting not found

--- a/src.ts/token.ts
+++ b/src.ts/token.ts
@@ -931,7 +931,7 @@ export class FungibleToken {
      * @param overrides options
      */
     static approveFungibleTokenOwnership(symbol: string, signer: Signer, overrides?: any) {
-        return setFungibleTokenStatus(symbol, "APPROVE_TRANFER_TOKEN_OWNERSHIP", signer, overrides);
+        return setFungibleTokenStatus(symbol, "APPROVE_TRANSFER_TOKEN_OWNERSHIP", signer, overrides);
     }
 
     /**
@@ -941,7 +941,7 @@ export class FungibleToken {
      * @param overrides options
      */
     static rejectFungibleTokenOwnership(symbol: string, signer: Signer, overrides?: any) {
-        return setFungibleTokenStatus(symbol, "REJECT_TRANFER_TOKEN_OWNERSHIP", signer, overrides);
+        return setFungibleTokenStatus(symbol, "REJECT_TRANSFER_TOKEN_OWNERSHIP", signer, overrides);
     }
 
     /**
@@ -1001,8 +1001,8 @@ function setFungibleTokenStatus(symbol: string, status: string, signer: Signer, 
         case "REJECT":
         case "FREEZE":
         case "UNFREEZE":
-        case "APPROVE_TRANFER_TOKEN_OWNERSHIP":
-        case "REJECT_TRANFER_TOKEN_OWNERSHIP":
+        case "APPROVE_TRANSFER_TOKEN_OWNERSHIP":
+        case "REJECT_TRANSFER_TOKEN_OWNERSHIP":
             break;
 
         default:


### PR DESCRIPTION
ft /nft
- fix spelling error APPROVE_TRANFER_TOKEN_OWNERSHIP to APPROVE_TRANSFER_TOKEN_OWNERSHIP
- fix spelling error REJECT_TRANFER_TOKEN_OWNERSHIP to REJECT_TRANSFER_TOKEN_OWNERSHIP
- fix error code

