### PR TITLE
added nft item's owner getter in nftitem.

### DIFF
--- a/src.ts/non-fungible-token-item.ts
+++ b/src.ts/non-fungible-token-item.ts
@@ -17,9 +17,11 @@ export class NonFungibleTokenItem {
 
     readonly signer: Signer;
     readonly provider: Provider;
-
+    
     readonly symbol: string;
     readonly itemID: string;
+
+    private _owner: string;
     private _state: NFTokenItemState;
     private _NFT: NonFungibleToken;
 
@@ -55,6 +57,8 @@ export class NonFungibleTokenItem {
 
     get parent() { return this._NFT; }
 
+    get owner() { return this._owner; }
+
     refresh(overrides?: any) {
         if (!this.symbol) {
             errors.throwError('not initialized', errors.NOT_INITIALIZED, { arg: 'symbol' });
@@ -67,6 +71,7 @@ export class NonFungibleTokenItem {
             return this.getParent({ ...overrides, queryOnly: true }).then((token) => {
                 this._state = state;
                 this._NFT = token;
+                this._owner = state.owner;
 
                 return this;
             });
@@ -77,7 +82,7 @@ export class NonFungibleTokenItem {
     * Query token item state
     * @param itemID itemID
     * @param blockTag reserved for future
-    * 
+    *
     */
     getState(blockTag?: BlockTag, overrides?: any) {
         if (!this.symbol) {
@@ -91,7 +96,7 @@ export class NonFungibleTokenItem {
             if (!result) {
                 errors.throwError('token item state is not available', errors.NOT_AVAILABLE, { arg: 'itemID' });
             }
-            if (this.itemID != result.id) {
+            if (this.itemID != result.item.id) {
                 errors.throwError('token item id mismatch', errors.UNEXPECTED_RESULT, { expected: this.itemID, returned: result });
             }
             if (!(overrides && overrides.queryOnly)) {

--- a/src.ts/non-fungible-token-item.ts
+++ b/src.ts/non-fungible-token-item.ts
@@ -17,11 +17,9 @@ export class NonFungibleTokenItem {
 
     readonly signer: Signer;
     readonly provider: Provider;
-    
     readonly symbol: string;
     readonly itemID: string;
 
-    private _owner: string;
     private _state: NFTokenItemState;
     private _NFT: NonFungibleToken;
 
@@ -53,11 +51,11 @@ export class NonFungibleTokenItem {
         }
     }
 
-    get state() { return this._state; }
+    get state() { return this._state ? this._state : {} as NFTokenItemState; }
 
     get parent() { return this._NFT; }
 
-    get owner() { return this._owner; }
+    get owner() { return this.state.owner; }
 
     refresh(overrides?: any) {
         if (!this.symbol) {
@@ -71,7 +69,6 @@ export class NonFungibleTokenItem {
             return this.getParent({ ...overrides, queryOnly: true }).then((token) => {
                 this._state = state;
                 this._NFT = token;
-                this._owner = state.owner;
 
                 return this;
             });
@@ -96,7 +93,7 @@ export class NonFungibleTokenItem {
             if (!result) {
                 errors.throwError('token item state is not available', errors.NOT_AVAILABLE, { arg: 'itemID' });
             }
-            if (this.itemID != result.item.id) {
+            if (this.itemID != result.id) {
                 errors.throwError('token item id mismatch', errors.UNEXPECTED_RESULT, { expected: this.itemID, returned: result });
             }
             if (!(overrides && overrides.queryOnly)) {

--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -67,13 +67,11 @@ export interface NFTokenState {
 
 export interface NFTokenItemState {
     owner: string,
-    item: {
-        id: string,
-        properties: string,
-        metadata: string,
-        transferLimit: BigNumber,
-        frozen: boolean
-    }
+    id: string,
+    properties: string,
+    metadata: string,
+    transferLimit: BigNumber,
+    frozen: boolean
 }
 
 

--- a/src.ts/providers/abstract-provider.ts
+++ b/src.ts/providers/abstract-provider.ts
@@ -66,11 +66,14 @@ export interface NFTokenState {
 }
 
 export interface NFTokenItemState {
-    id: string,
-    properties: string,
-    metadata: string,
-    transferLimit: BigNumber,
-    frozen: boolean
+    owner: string,
+    item: {
+        id: string,
+        properties: string,
+        metadata: string,
+        transferLimit: BigNumber,
+        frozen: boolean
+    }
 }
 
 

--- a/src.ts/providers/base-provider.ts
+++ b/src.ts/providers/base-provider.ts
@@ -146,7 +146,6 @@ function checkNonFungibleTokenItemState(data: any): NFTokenItemState {
     }, data), (key) => {
         switch (key) {
             case "Owner": return "owner";
-            case "Item": return "item";
             case "ID": return "id";
             case "Metadata": return "metadata";
             case "Properties": return "properties";

--- a/src.ts/providers/base-provider.ts
+++ b/src.ts/providers/base-provider.ts
@@ -138,14 +138,11 @@ function checkNonFungibleTokenState(data: any): NFTokenState {
 function checkNonFungibleTokenItemState(data: any): NFTokenItemState {
     return camelize(checkFormat({
         Owner: checkString,
-        Item: {
-            ID: checkString,
-            Metadata: allowNullOrEmpty(checkString),
-            Properties: allowNullOrEmpty(checkString),
-            Frozen: checkBoolean,
-            TransferLimit: checkBigNumber
-        }
-
+        ID: checkString,
+        Metadata: allowNullOrEmpty(checkString),
+        Properties: allowNullOrEmpty(checkString),
+        Frozen: checkBoolean,
+        TransferLimit: checkBigNumber
     }, data), (key) => {
         switch (key) {
             case "Owner": return "owner";

--- a/src.ts/providers/base-provider.ts
+++ b/src.ts/providers/base-provider.ts
@@ -137,14 +137,19 @@ function checkNonFungibleTokenState(data: any): NFTokenState {
 
 function checkNonFungibleTokenItemState(data: any): NFTokenItemState {
     return camelize(checkFormat({
-        ID: checkString,
-        Metadata: allowNullOrEmpty(checkString),
-        Properties: allowNullOrEmpty(checkString),
-        Frozen: checkBoolean,
-        TransferLimit: checkBigNumber
+        Owner: checkString,
+        Item: {
+            ID: checkString,
+            Metadata: allowNullOrEmpty(checkString),
+            Properties: allowNullOrEmpty(checkString),
+            Frozen: checkBoolean,
+            TransferLimit: checkBigNumber
+        }
 
     }, data), (key) => {
         switch (key) {
+            case "Owner": return "owner";
+            case "Item": return "item";
             case "ID": return "id";
             case "Metadata": return "metadata";
             case "Properties": return "properties";

--- a/tests/test-0800-non-fungible-token.ts
+++ b/tests/test-0800-non-fungible-token.ts
@@ -475,7 +475,7 @@ if ("" != nodeProvider.nonFungibleToken.middleware) {
                                 it("Get item parent properties", function () {
                                     return NonFungibleTokenItem.fromSymbol(symbol, itemId, wallet).then((nftItem) => {
                                         expect(nftItem).exist;
-                                        expect(nftItem.owner).exist;
+                                        expect(nftItem).have.property("owner").is.eq(wallet.address);
                                         expect(nftItem).have.property("symbol").is.eq(symbol);
                                         expect(nftItem).have.property("itemID").is.eq(itemId);
                                         expect(nftItem).have.property("parent").have.property("symbol").is.eq(symbol);
@@ -486,7 +486,7 @@ if ("" != nodeProvider.nonFungibleToken.middleware) {
                                 it("Update NFT item metadata - non holder", function () {
                                     return NonFungibleTokenItem.fromSymbol(symbol, itemId, modifiable ? issuer : wallet).then((nftItem) => {
                                         expect(nftItem).exist;
-                                        expect(nftItem.owner).exist;
+                                        expect(nftItem).have.property("owner").is.eq(wallet.address);
                                         expect(nftItem).have.property("symbol").is.eq(symbol);
                                         expect(nftItem).have.property("itemID").is.eq(itemId);
                                         expect(nftItem).have.property("parent").have.property("symbol").is.eq(symbol);
@@ -502,7 +502,7 @@ if ("" != nodeProvider.nonFungibleToken.middleware) {
                                 it("Update NFT item metadata", function () {
                                     return NonFungibleTokenItem.fromSymbol(symbol, itemId, modifiable ? wallet : issuer).then((nftItem) => {
                                         expect(nftItem).exist;
-                                        expect(nftItem.owner).exist;
+                                        expect(nftItem).have.property("owner").is.eq(wallet.address);
                                         expect(nftItem).have.property("symbol").is.eq(symbol);
                                         expect(nftItem).have.property("itemID").is.eq(itemId);
                                         expect(nftItem).have.property("parent").have.property("symbol").is.eq(symbol);
@@ -703,7 +703,7 @@ if ("" != nodeProvider.nonFungibleToken.middleware) {
                                 it("Freeze NFT - update item metadata should not be allowed", function () {
                                     return NonFungibleTokenItem.fromSymbol(symbol, itemId, modifiable ? wallet : issuer).then((nftItem) => {
                                         expect(nftItem).exist;
-                                        expect(nftItem.owner).exist;
+                                        expect(nftItem).have.property("owner").is.eq(wallet.address);
                                         expect(nftItem).have.property("symbol").is.eq(symbol);
                                         expect(nftItem).have.property("itemID").is.eq(itemId);
                                         expect(nftItem).have.property("parent").have.property("symbol").is.eq(symbol);

--- a/tests/test-0800-non-fungible-token.ts
+++ b/tests/test-0800-non-fungible-token.ts
@@ -467,7 +467,7 @@ if ("" != nodeProvider.nonFungibleToken.middleware) {
                                         return token.mint(wallet.address, itemProp).then((receipt) => {
                                             expect(receipt).is.not.exist;
                                         }).catch(error => {
-                                            expect(error).have.property("code").to.eq(errors.UNEXPECTED_RESULT);
+                                            expect(error).have.property("code").to.eq(errors.NOT_ALLOWED);
                                         });
                                     });
                                 });
@@ -475,6 +475,7 @@ if ("" != nodeProvider.nonFungibleToken.middleware) {
                                 it("Get item parent properties", function () {
                                     return NonFungibleTokenItem.fromSymbol(symbol, itemId, wallet).then((nftItem) => {
                                         expect(nftItem).exist;
+                                        expect(nftItem.owner).exist;
                                         expect(nftItem).have.property("symbol").is.eq(symbol);
                                         expect(nftItem).have.property("itemID").is.eq(itemId);
                                         expect(nftItem).have.property("parent").have.property("symbol").is.eq(symbol);
@@ -485,6 +486,7 @@ if ("" != nodeProvider.nonFungibleToken.middleware) {
                                 it("Update NFT item metadata - non holder", function () {
                                     return NonFungibleTokenItem.fromSymbol(symbol, itemId, modifiable ? issuer : wallet).then((nftItem) => {
                                         expect(nftItem).exist;
+                                        expect(nftItem.owner).exist;
                                         expect(nftItem).have.property("symbol").is.eq(symbol);
                                         expect(nftItem).have.property("itemID").is.eq(itemId);
                                         expect(nftItem).have.property("parent").have.property("symbol").is.eq(symbol);
@@ -500,6 +502,7 @@ if ("" != nodeProvider.nonFungibleToken.middleware) {
                                 it("Update NFT item metadata", function () {
                                     return NonFungibleTokenItem.fromSymbol(symbol, itemId, modifiable ? wallet : issuer).then((nftItem) => {
                                         expect(nftItem).exist;
+                                        expect(nftItem.owner).exist;
                                         expect(nftItem).have.property("symbol").is.eq(symbol);
                                         expect(nftItem).have.property("itemID").is.eq(itemId);
                                         expect(nftItem).have.property("parent").have.property("symbol").is.eq(symbol);
@@ -525,7 +528,7 @@ if ("" != nodeProvider.nonFungibleToken.middleware) {
                                         expect(receipt).is.not.exist;
                                     }).catch(error => {
                                         if (!transferable) expect(error).have.property("code").to.eq(errors.NOT_ALLOWED);
-                                        else expect(error).have.property("code").to.eq(errors.UNEXPECTED_RESULT);
+                                        else expect(error).have.property("code").to.eq(errors.NOT_ALLOWED);
                                     });
                                 });
 
@@ -700,6 +703,7 @@ if ("" != nodeProvider.nonFungibleToken.middleware) {
                                 it("Freeze NFT - update item metadata should not be allowed", function () {
                                     return NonFungibleTokenItem.fromSymbol(symbol, itemId, modifiable ? wallet : issuer).then((nftItem) => {
                                         expect(nftItem).exist;
+                                        expect(nftItem.owner).exist;
                                         expect(nftItem).have.property("symbol").is.eq(symbol);
                                         expect(nftItem).have.property("itemID").is.eq(itemId);
                                         expect(nftItem).have.property("parent").have.property("symbol").is.eq(symbol);


### PR DESCRIPTION
- Added getter for nft item's owner
- Added expecting owner after initialise item instance in test cases
- Edit NFTItemState to have owner

The owner did not add as one of the constructor's element because there is a signer and provider, it could be confusing. However, the owner added as a private value and it is accessible after NFT item being initialised.